### PR TITLE
[generatingvectors] add cbcpt_cfftw2_10 to qmc.hpp

### DIFF
--- a/src/qmc.hpp
+++ b/src/qmc.hpp
@@ -101,6 +101,7 @@ namespace integrators
 #include "generatingvectors/cbcpt_dn1_100.hpp"
 #include "generatingvectors/cbcpt_dn2_6.hpp"
 #include "generatingvectors/cbcpt_cfftw1_6.hpp"
+#include "generatingvectors/cbcpt_cfftw2_10.hpp"
 #include "core/cuda/compute_kernel.hpp"
 #include "core/cuda/compute.hpp"
 #include "core/cuda/setup.hpp"


### PR DESCRIPTION
This also instructs make_singleheader.py include it in the bundle.

A small followup on 8a3ea43a4b52f2e9c2d6b810fdc5c1d92ebc9da4